### PR TITLE
Django apps: Add path to the binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ If you run into issues when trying to deploy with this buildpack, make sure your
 $ heroku stack
 ```
 
+## Django apps: Path to the binary
+
+If your Django app cannot find the wkhtmltopdf binary on Heroku, try adding/updating your settings.py
+
+`WKHTMLTOPDF_CMD = './bin/wkhtmltopdf'`
+
+
 If you are on an older stack, you can upgrade to `cedar-14` with:
 
 ```bash


### PR DESCRIPTION
Some Django applications (like mine for example) cannot automatically discover the wkhtmltopdf binary which the buildpack sets. In Readme, I added a small hint for Django users who might struggle with pointing their Heroku apps to the wkhtmltopdf binary.